### PR TITLE
Fix reference to i18nextElectronBackend

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ class Backend {
         this.mainLog = `${logPrepend}main]=>`;
         this.rendererLog = `${logPrepend}renderer]=>`;
 
-        if (typeof this.i18nextElectronBackend === "undefined"){
+        if (typeof this.backendOptions.i18nextElectronBackend === "undefined"){
             console.error(`${this.rendererLog} i18nextElectronBackend is undefined, please ensure you are exposing i18nextElectronBackend via the contextBridge in your preload file.`);
             return;
         }


### PR DESCRIPTION
I ran into this after upgrading to the latest version. Seems like you meant to reference `this.backendOptions.i18nextElectronBackend` instead